### PR TITLE
IFIX for NPE extended message RTV_SEND case should assign classSig a value

### DIFF
--- a/runtime/vm/extendedMessageNPE.cpp
+++ b/runtime/vm/extendedMessageNPE.cpp
@@ -1608,21 +1608,29 @@ simulateStack(J9NPEMessageData *npeMsgData)
 		case RTV_SEND: {
 			J9UTF8 *classSig = NULL;
 
+			Trc_VM_simulateStack_RTVSEND_bcIndex(vmThread, currentBytecode, bcIndex);
 			if (JBinvokeinterface2 == currentBytecode) {
-				/* Set to point to JBinvokeinterface */
+				/* Set to point to JBinvokeinterface. */
 				bcIndex += 2;
+				Trc_VM_simulateStack_RTVSEND_bcIndex2(vmThread, bcIndex);
 			}
 			UDATA index = PARAM_16(bcIndex, 1);
+			Trc_VM_simulateStack_RTVSEND_index(vmThread, index);
 			if (JBinvokestaticsplit == currentBytecode) {
 				index = *(U_16 *)(J9ROMCLASS_STATICSPLITMETHODREFINDEXES(romClass) + index);
+				Trc_VM_simulateStack_RTVSEND_JBinvokestaticsplit_index(vmThread, index);
 			} else if (JBinvokespecialsplit == currentBytecode) {
 				index = *(U_16 *)(J9ROMCLASS_SPECIALSPLITMETHODREFINDEXES(romClass) + index);
-			} else if (JBinvokedynamic == currentBytecode) {
+				Trc_VM_simulateStack_RTVSEND_JBinvokespecialsplit_index(vmThread, index);
+			}
+			if (JBinvokedynamic == currentBytecode) {
 				J9SRP *callSiteData = (J9SRP *) J9ROMCLASS_CALLSITEDATA(romClass);
 				classSig = ((J9UTF8 *) (J9ROMNAMEANDSIGNATURE_SIGNATURE(SRP_PTR_GET(callSiteData + index, J9ROMNameAndSignature*))));
+				Trc_VM_simulateStack_RTVSEND_JBinvokedynamic_classSig(vmThread, J9UTF8_LENGTH(classSig), J9UTF8_DATA(classSig));
 			} else {
 				J9ROMConstantPoolItem *info = &constantPool[index];
 				classSig = ((J9UTF8 *) (J9ROMNAMEANDSIGNATURE_SIGNATURE(J9ROMMETHODREF_NAMEANDSIGNATURE((J9ROMMethodRef *) info))));
+				Trc_VM_simulateStack_RTVSEND_others_classSig(vmThread, J9UTF8_LENGTH(classSig), J9UTF8_DATA(classSig));
 			}
 			stackTop -= getSendSlotsFromSignature(J9UTF8_DATA(classSig));
 

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -973,3 +973,11 @@ TraceEvent=Trc_VM_ComputeNPEMsgAtPC_end Overhead=1 Level=3 Template="ComputeNPEM
 TraceExit=Trc_VM_ComputeNPEMsgAtPC_Exit Overhead=1 Level=3 Template="ComputeNPEMsgAtPC : npePC (0x%zx) npeFlag (%d) isMethodFlag (%d) npeMsg (%s)"
 
 TraceEvent=Trc_VM_allocateClassLoader_SetFlag NoEnv Overhead=1 Level=3 Template="allocateClassLoader set flag J9CLASSLOADER_SHARED_CLASSES_ENABLED for class loader (%p)"
+
+TraceEvent=Trc_VM_simulateStack_RTVSEND_bcIndex Overhead=1 Level=5 Template="simulateStack RTV_SEND starts currentBytecode(%zu) bcIndex(%p)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_bcIndex2 Overhead=1 Level=5 Template="simulateStack RTV_SEND bcIndex2(%p)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_index Overhead=1 Level=5 Template="simulateStack RTV_SEND index(%zu)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_JBinvokestaticsplit_index Overhead=1 Level=3 Template="simulateStack RTV_SEND JBinvokestaticsplit index(%zu)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_JBinvokespecialsplit_index Overhead=1 Level=3 Template="simulateStack RTV_SEND JBinvokespecialsplit index(%zu)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_JBinvokedynamic_classSig Overhead=1 Level=5 Template="simulateStack RTV_SEND JBinvokedynamic classSig(%.*s)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_others_classSig Overhead=1 Level=5 Template="simulateStack RTV_SEND others classSig(%.*s)"


### PR DESCRIPTION
In simulateStack() RTV_SEND case, classSig should always be assigned a value instead of using the initial NULL.